### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/cloud/Dockerfile.tmpl
+++ b/cloud/Dockerfile.tmpl
@@ -11,7 +11,7 @@ ARG BUNDLE_DIR
 # ENV no_proxy=localhost,127.0.0.1
 
 RUN apt-get update && apt-get install -y ca-certificates git python3-pip jq
-RUN pip3 install ansible netaddr
+RUN pip3 install --no-cache-dir ansible netaddr
 
 # This is a template Dockerfile for the bundle's invocation image
 # You can customize it to use different base images, install tools and copy configuration files.

--- a/roles/telemetry/collectd/controlplane/files/Dockerfile
+++ b/roles/telemetry/collectd/controlplane/files/Dockerfile
@@ -7,7 +7,7 @@ ENV http_proxy=$http_proxy
 ENV https_proxy=$https_proxy
 
 RUN yum install -y gcc gcc-c++ cmake make autoconf automake libxml2 libxml2-devel json-c-devel boost ncurses ncurses-devel ncurses-libs boost-devel libuuid libuuid-devel python2-jsonschema doxygen hwloc-devel libpng12 rsync openssl-devel bc python-devel python-libs python-sphinx openssl unzip which wget python36 epel-release flex bison libtool pkgconfig git patch OpenIPMI ipmitool OpenIPMI-devel yajl yajl-devel protobuf-c protobuf-c-devel libmicrohttpd libmicrohttpd-devel
-RUN easy_install pip && pip install intelhex
+RUN easy_install pip && pip install --no-cache-dir intelhex
 
 # RT repo
 RUN wget http://linuxsoft.cern.ch/cern/centos/7/rt/CentOS-RT.repo -O /etc/yum.repos.d/CentOS-RT.repo


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik raj <rajpratik71@gmail.com>