### PR TITLE
Update configMap.yml

### DIFF
--- a/roles/kubernetes/cni/sriov/controlplane/files/sriov/templates/configMap.yml
+++ b/roles/kubernetes/cni/sriov/controlplane/files/sriov/templates/configMap.yml
@@ -13,8 +13,8 @@ data:
                 "resourceName": "intel_sriov_netdevice",
                 "selectors": {
                     "vendors": ["8086"],
-                    "devices": ["154c", "10ed"],
-                    "drivers": ["iavf", "i40evf", "ixgbevf"]
+                    "devices": ["154c", "10ed","1520"],
+                    "drivers": ["iavf", "i40evf", "ixgbevf","igbvf"]
                 }
             },
             {{- if .Values.sriov_kubevirt_enable }}


### PR DESCRIPTION
The default poll mode driver of virtual functions for Intel Corporation I350 NIC is igbvf. In order to allocate sriov net devices bound to igbvf driver, they need to be added to the intel_sriov_netdevice resource pool by the sriov device plugin. The above changes allow the VFs to be allocated to the pods.