### PR TITLE
latest ca-certificates needed to download at least openssl

### DIFF
--- a/roles/infrastructure/os_setup/tasks/install_base_os_packages.yml
+++ b/roles/infrastructure/os_setup/tasks/install_base_os_packages.yml
@@ -5,6 +5,14 @@
 - debug:
     msg: "Installing the following packages: {{ os_yum_base_packages }}"
 
+
+- name: install latest ca-certificates
+  yum:
+    name: ca-certificates
+    state: latest
+  become: yes
+  when: not offline_enable
+
 - name: install IUS repository
   yum:
     name: https://repo.ius.io/ius-release-el7.rpm


### PR DESCRIPTION
If non latest ca-certificates is in use it could lead to ansible failing on get_url when downloading essential archives like OpenSSL