### PR TITLE
modify ansible-precheck.sh ansible version

### DIFF
--- a/scripts/ansible-precheck.sh
+++ b/scripts/ansible-precheck.sh
@@ -17,7 +17,7 @@ PYTHON_PYYAML_PKG=python36-PyYAML
 PYTHON_PYYAML_VERSION=3.13-1.el7
 
 ANSIBLE_PKG=ansible
-ANSIBLE_VERSION=2.9.25-1.el7
+ANSIBLE_VERSION=2.9.27-1.el7
 
 ensure_installed () {
   if [[ ${2-} ]]


### PR DESCRIPTION
Signed-off-by: ji3k54j062k7 <ji3k54g4j062k7@gmail.com>
Using `scripts/ansible-precheck.sh` will give an error message:
![圖片](https://user-images.githubusercontent.com/33923746/155328945-59090a44-cd05-4723-8521-e541b1e2dade.png)
Changing ANSIBLE_VERSION to 2.9.27-1.el7 solved the problem .